### PR TITLE
Patch for labelling error

### DIFF
--- a/src/storm-pomdp/builder/BeliefMdpExplorer.cpp
+++ b/src/storm-pomdp/builder/BeliefMdpExplorer.cpp
@@ -379,7 +379,7 @@ namespace storm {
             STORM_LOG_ASSERT(currentStateHasOldBehavior(), "Method 'actionAtCurrentStateWasOptimal' called but current state has no old behavior");
             STORM_LOG_ASSERT(exploredMdp, "No 'old' mdp available");
             uint64_t choice = exploredMdp->getNondeterministicChoiceIndices()[getCurrentMdpState()] + localActionIndex;
-            return exploredMdp->hasChoiceLabeling() && exploredMdp->getChoiceLabeling().getChoiceHasLabel("delayed", choice);
+            return exploredMdp->hasChoiceLabeling() && exploredMdp->getChoiceLabeling().getLabels().count("delayed") > 0 && exploredMdp->getChoiceLabeling().getChoiceHasLabel("delayed", choice);
         }
 
         template<typename PomdpType, typename BeliefValueType>

--- a/src/test/storm-pomdp/modelchecker/BeliefExplorationPomdpModelCheckerTest.cpp
+++ b/src/test/storm-pomdp/modelchecker/BeliefExplorationPomdpModelCheckerTest.cpp
@@ -123,7 +123,7 @@ namespace {
         static void adaptOptions(storm::pomdp::modelchecker::BeliefExplorationPomdpModelCheckerOptions<ValueType>& options) {options.refine = true; options.refinePrecision = precision();}
     };
 
-    class PreprocessedCullingDoubleVIEnvironment {
+    class PreprocessedClippingDoubleVIEnvironment {
     public:
         typedef double ValueType;
         static storm::Environment createEnvironment() {
@@ -262,7 +262,7 @@ namespace {
             DefaultDoubleOVIEnvironment,
             DefaultRationalPIEnvironment,
             PreprocessedDefaultRationalPIEnvironment,
-            PreprocessedCullingDoubleVIEnvironment
+            PreprocessedClippingDoubleVIEnvironment
     > TestingTypes;
     
     TYPED_TEST_SUITE(BeliefExplorationTest, TestingTypes,);


### PR DESCRIPTION
This is the patch that skips the label renaming if no explicit cut-offs are requested.